### PR TITLE
Force users to use exact flags.  Moved configuration to remove ambiguity

### DIFF
--- a/scripts/ADF_SSN_03_ADF_all_Observers.py
+++ b/scripts/ADF_SSN_03_ADF_all_Observers.py
@@ -12,14 +12,30 @@ parser.add_argument('-q',"--QDF", action='store_true')
 parser.add_argument('-m',"--month", action='store_true')
 args, leftovers = parser.parse_known_args()
 
+#################
+# CONFIGURATION #
+#################
+
+# Observer ID range and who to skip
+SSN_ADF_Config.OBS_START_ID = 412
+SSN_ADF_Config.OBS_END_ID = 600
+SSN_ADF_Config.SKIP_OBS = [332]
+
+# Quantity to use in the numerator of the ADF:  Active days or 1-quiet days
 if args.QDF is not None:
-    SSN_ADF_Config.ADF_TYPE = "QDF"
+    SSN_ADF_Config.ADF_TYPE = "ADF"   # Set to 'ADF' (QDF) to use ADF (1-QDF) calculation.
+
+# Quantity to use in the denominator:  Oserved days or the full month
 if args.month is not None:
-    SSN_ADF_Config.MONTH_TYPE = "FULL"
+    SSN_ADF_Config.MONTH_TYPE = "FULLM" # Set to 'OBS' ('FULLM') to use observed days (full month length) to determine ADF
 
-
+# Flag to turn on saving of figures
 plotSwitch = True
+
+# Output Folder
 output_path = 'TestFrag'
+
+#################
 
 # Read Data and plot reference search windows, minima and maxima
 ssn_adf = ssnADF(ref_data_path='../input_data/SC_SP_RG_DB_KM_group_areas_by_day.csv',

--- a/scripts/SSN_ADF.py
+++ b/scripts/SSN_ADF.py
@@ -601,7 +601,7 @@ class ssnADF(ssn_data):
                 else:
                     cadMaskI = ssn_data.decMask['INDEX']
 
-                    # Pre-allocating EMD matrix and associated coordinate matrices.  A large default distance valued is used
+                # Pre-allocating EMD matrix and associated coordinate matrices.  A large default distance valued is used
                 # to account for missing points
                 EMD = np.ones((GDREFI[siInx].shape[0], GDREFI[siInx].shape[1])) * 1e16
                 EMDt = np.zeros((GDREFI[siInx].shape[0], GDREFI[siInx].shape[1]))
@@ -617,14 +617,17 @@ class ssnADF(ssn_data):
                             # Calculating Earth Mover's Distance
 
                             # Change denom depending on
-                            if SSN_ADF_Config.MONTH_TYPE == "FULL":
+                            if SSN_ADF_Config.MONTH_TYPE == "FULLM":
                                 ADF_Obs_denom = ssn_data.MoLngt
                                 ADF_REF_denom = ssn_data.MoLngt
-                            else:
+                            elif SSN_ADF_Config.MONTH_TYPE == "OBS":
                                 ADF_Obs_denom = ODObsI[siInx][
                                     TIdx, SIdx, ODObsI[siInx][TIdx, SIdx, :] / ssn_data.MoLngt >= ssn_data.minObD]
                                 ADF_REF_denom = ODREFI[siInx][
                                     TIdx, SIdx, ODREFI[siInx][TIdx, SIdx, :] / ssn_data.MoLngt >= ssn_data.minObD]
+                            else:
+                                raise ValueError(
+                                    'Invalid flag: Use \'OBS\' (or \'FULLM\') to use observed days (full month length) to determine ADF.')
 
                             # Change calculation depending on ADF/QDF flag
                             if SSN_ADF_Config.ADF_TYPE == "QDF":
@@ -635,13 +638,16 @@ class ssnADF(ssn_data):
 
                                 ADF_Obs_frac = 1.0 - np.divide(ADF_Obs_numerator, ADF_Obs_denom)
                                 ADF_REF_frac = 1.0 - np.divide(ADF_REF_numerator, ADF_REF_denom)
-                            else:
+                            elif SSN_ADF_Config.ADF_TYPE == "ADF":
                                 ADF_Obs_numerator = GDObsI[siInx][
                                     TIdx, SIdx, ODObsI[siInx][TIdx, SIdx, :] / ssn_data.MoLngt >= ssn_data.minObD]
                                 ADF_REF_numerator = GDREFI[siInx][
                                     TIdx, SIdx, ODREFI[siInx][TIdx, SIdx, :] / ssn_data.MoLngt >= ssn_data.minObD]
                                 ADF_Obs_frac = np.divide(ADF_Obs_numerator, ADF_Obs_denom)
                                 ADF_REF_frac = np.divide(ADF_REF_numerator, ADF_REF_denom)
+                            else:
+                                raise ValueError(
+                                    'Invalid flag: Use \'ADF\' (or \'QDF\') for active (1-quiet) day fraction.')
 
                             # Main ADF calculations
                             ADFObs, bins = np.histogram(ADF_Obs_frac,

--- a/scripts/SSN_Config.py
+++ b/scripts/SSN_Config.py
@@ -15,13 +15,13 @@ class SSN_ADF_Config:
     """
 
     # Observer ID range and who to skip
-    OBS_START_ID = 412
-    OBS_END_ID = 600
-    SKIP_OBS = [332]
+    OBS_START_ID = []
+    OBS_END_ID = []
+    SKIP_OBS = []
 
     # ADF variables
-    ADF_TYPE = "QDF"  # Set to 'QDF' to use 1-QDF calculation. Anything else will use ADF
-    MONTH_TYPE = "ACTIVE"  # Set to 'FULL' to use full month fraction calculation. Anything else will use Obs days
+    ADF_TYPE = ""  # Set to 'ADF' (QDF) to use ADF (1-QDF) calculation.
+    MONTH_TYPE = ""  # Set to 'OBS' ('FULLM') to use observed days (full month length) to determine ADF
 
     # Plotting config varibales
     PLOT_OPTIMAL_THRESH = True
@@ -37,13 +37,18 @@ class SSN_ADF_Config:
     @staticmethod
     def get_file_prepend(adf_type, month_type):
         if adf_type == "ADF":
+            prepend = "A_"
+        elif adf_type == "QDF":
             prepend = "Q_"
         else:
-            prepend = "A_"
-        if month_type == "X":
+            raise ValueError('Invalid flag: Use \'ADF\' (or \'QDF\') for active (1-quiet) day fraction.')
+
+        if month_type == "FULLM":
             prepend += "M_"
-        else:
+        elif month_type == "OBS":
             prepend += "O_"
+        else:
+            raise ValueError('Invalid flag: Use \'OBS\' (or \'FULLM\') to use observed days (full month length) to determine ADF.')
         return prepend
 
     @staticmethod


### PR DESCRIPTION
- Changed flag names slightly and forced users to use exact spelling.
- Changed the config file and main file so that users know which one is determining the properties of their run